### PR TITLE
Add ability to get message field from Nextcloud response.

### DIFF
--- a/src/NextcloudApiWrapper/NextcloudResponse.php
+++ b/src/NextcloudApiWrapper/NextcloudResponse.php
@@ -42,7 +42,7 @@ class NextcloudResponse
      */
     public function getMessage() {
 
-        return (isset($this->body->meta->message) ? (string)$this->body->meta->message : '');
+        return (isset($this->body->meta->message) ? (string)$this->body->meta->message : null);
     }
 
     /**

--- a/src/NextcloudApiWrapper/NextcloudResponse.php
+++ b/src/NextcloudApiWrapper/NextcloudResponse.php
@@ -37,6 +37,15 @@ class NextcloudResponse
     }
 
     /**
+     * Returns nextcloud message
+     * @return string
+     */
+    public function getMessage() {
+
+        return (isset($this->body->meta->message) ? (string)$this->body->meta->message : '');
+    }
+
+    /**
      * Returns nextcloud status code
      * @return int
      */


### PR DESCRIPTION
I've added the ability to also get the `message` field from the Nextcloud response.

```
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>100</statuscode>
  <message>Nextcloud message...</message>
 </meta>
 <data/>
</ocs>
```