### PR TITLE
Fixes for link shares

### DIFF
--- a/src/NextcloudApiWrapper/SharesClient.php
+++ b/src/NextcloudApiWrapper/SharesClient.php
@@ -57,12 +57,13 @@ class SharesClient extends AbstractClient
         $params = $this->resolve($params, function(OptionsResolver $resolver) {
             $resolver->setRequired([
                 'path',
-                'shareType',
-                'shareWith'
+                'shareType'
             ])->setDefaults([
+                'shareWith'     => null,
                 'publicUpload'  => null,
                 'password'      => null,
-                'permissions'   => null
+                'permissions'   => null,
+                'expireDate'    => null
             ]);
         });
 


### PR DESCRIPTION
When creating a link share ('shareType' => 3), 'shareWith' is optional (in fact, the parameter will be ignored if given).

Additionally, 'expireDate' is not only available when updating a share, but also when creating one. The server processes and stores it correctly.

Tested on NextCloud 14.0.1