### PR TITLE
Add support for Nextcloud 14, also compatible with Nextcloud 15

### DIFF
--- a/src/NextcloudApiWrapper/NextCloudVersion14/AppsClient.php
+++ b/src/NextcloudApiWrapper/NextCloudVersion14/AppsClient.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace NextcloudApiWrapper\NextCloudVersion14;
+
+class AppsClient extends \NextcloudApiWrapper\AbstractClient
+{
+
+}

--- a/src/NextcloudApiWrapper/NextCloudVersion14/FederatedCloudSharesClient.php
+++ b/src/NextcloudApiWrapper/NextCloudVersion14/FederatedCloudSharesClient.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace NextcloudApiWrapper\NextCloudVersion14;
+
+class FederatedCloudSharesClient extends \NextcloudApiWrapper\AbstractClient
+{
+
+}

--- a/src/NextcloudApiWrapper/NextCloudVersion14/GroupsClient.php
+++ b/src/NextcloudApiWrapper/NextCloudVersion14/GroupsClient.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace NextcloudApiWrapper\NextCloudVersion14;
+
+class GroupsClient extends \NextcloudApiWrapper\AbstractClient
+{
+
+}

--- a/src/NextcloudApiWrapper/NextCloudVersion14/SharesClient.php
+++ b/src/NextcloudApiWrapper/NextCloudVersion14/SharesClient.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace NextcloudApiWrapper\NextCloudVersion14;
+
+class SharesClient extends \NextcloudApiWrapper\AbstractClient
+{
+
+}

--- a/src/NextcloudApiWrapper/NextCloudVersion14/UsersClient.php
+++ b/src/NextcloudApiWrapper/NextCloudVersion14/UsersClient.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NextcloudApiWrapper\NextCloudVersion14;
+
+use \NextcloudApiWrapper\Connection;
+use \NextcloudApiWrapper\NextcloudResponse;
+
+class UsersClient extends \NextcloudApiWrapper\UsersClient
+{
+
+    /**
+     * Adds a user.
+     * @param $username
+     * @param $password
+     * @param string $displayName
+     * @param string $email
+     * @param array $groups
+     * @param array $subadmin
+     * @param string $quota
+     * @param string $language
+     * @return NextcloudResponse
+     */
+    public function addUser($username,
+                            $password,
+                            $displayName = '',
+                            $email = '',
+                            $groups = [],
+                            $subadmin = [],
+                            $quota = '',
+                            $language = '')
+    {
+
+        return $this->connection->submitRequest(Connection::POST, self::USER_PART, [
+            'userid' => $username,
+            'password' => $password,
+            'displayName' => $displayName,
+            'email' => $email,
+            'groups' => $groups,
+            'subadmin' => $subadmin,
+            'quota' => $quota,
+            'language' => $language
+        ]);
+    }
+}

--- a/src/NextcloudApiWrapper/NextCloudVersion14/Wrapper.php
+++ b/src/NextcloudApiWrapper/NextCloudVersion14/Wrapper.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace NextcloudApiWrapper\NextCloudVersion14;
+
+use \NextcloudApiWrapper\Connection;
+
+class Wrapper extends \NextcloudApiWrapper\Wrapper
+{
+
+    public function __construct(Connection $connection)
+    {
+        parent::__construct($connection);
+    }
+
+    /**
+     * @return UsersClient
+     */
+    public function getUsersClient() {
+
+        return $this->getClient(UsersClient::class);
+    }
+}

--- a/src/NextcloudApiWrapper/Wrapper.php
+++ b/src/NextcloudApiWrapper/Wrapper.php
@@ -14,7 +14,7 @@ class Wrapper
      */
     protected $clients  = [];
 
-    private function __construct(Connection $connection)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
     }
@@ -22,7 +22,7 @@ class Wrapper
     public static function build($baseUri, $username, $password) {
 
         $connection = new Connection($baseUri, $username, $password);
-        return new Wrapper($connection);
+        return new static($connection);
     }
 
     /**


### PR DESCRIPTION
### Background and grounds for PR
Since Nextcloud are adding features without updating the API version, I believe it makes sense to introduce the tracking of **Nextcloud versions** in this library.
If only **API version** would be tracked, it will be hard for users of this library to know whether the version of the library will be compatible with the version of Nextcloud.

For instance **Nextcloud 14** has added a few parameters to the user provisioning endpoint.
The API version is not bumped though _(which is of course totally fine)_.
If these new parameters would have been added to the current `UsersClient`, then all of a sudden it would not have been backwards compatible. And I'm reluctant to introduce versioning inside the class.

What was done instead is that a new namespace, `NextCloudVersion14`, was introduced in the library.
In that way no current users are affected, and those who are upgrading to **Nextcloud 14**, **15** and so on can easily switch.

Current users bootstrap the library like this _(as stated in README - nothing has changed)_:

    $wrapper = \NextcloudApiWrapper\Wrapper::build(...);

For users of Nextcloud 14 it would instead be like this:

    $wrapper  = \NextcloudApiWrapper\NextCloudVersion14\Wrapper::build(...);

Code wise there are very few changes, as the classes I've created in the `NextCloudVersion14` namespace inherits all functionality from the original classes, copying their exact behaviour.
The only class which actually extends functionality is the `UsersClient` which now accepts more parameters.

### Two small changes in the original wrapper
- Change the constructor to be **public**.
- In `build()`, call `new static` instead of hard coded `new Wrapper` to let the current namespace decide which version of the `Wrapper` which is instantiated.