### PR TITLE
Fixes on ShareClient for NC 21

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^6.3",
-        "symfony/options-resolver": "^3.4"
+        "guzzlehttp/guzzle": "^7.3",
+        "symfony/options-resolver": "^5.3"
     },
     "autoload": {
         "psr-4": {"NextcloudApiWrapper\\": "src/NextcloudApiWrapper"}

--- a/src/NextcloudApiWrapper/SharesClient.php
+++ b/src/NextcloudApiWrapper/SharesClient.php
@@ -27,8 +27,8 @@ class SharesClient extends AbstractClient
 
         $params = $this->resolve($params, function(OptionsResolver $resolver) {
             $resolver->setDefaults([
-                'reshares'	=> null,
-                'subfiles'	=> null
+                'reshares'  => null,
+                'subfiles'  => null
             ]);
         });
 
@@ -91,7 +91,7 @@ class SharesClient extends AbstractClient
 
         $this->inArray($key, ['permissions', 'password', 'publicUpload', 'expireDate', 'note']);
 
-        return $this->connection->pushDataRequest(Connection::PUT, self::SHARE_PART . '/' . $shareid, [
+        return $this->connection->submitRequest(Connection::PUT, self::SHARE_PART . '/' . $shareid, [
             $key => $value
         ]);
     }

--- a/src/NextcloudApiWrapper/SharesClient.php
+++ b/src/NextcloudApiWrapper/SharesClient.php
@@ -20,21 +20,21 @@ class SharesClient extends AbstractClient
     /**
      * Get all shares from a given file/folder
      * @param $path
-     * @param array $params, can have keys 'reshares' (bool), 'subfiles' (bool)
+     * @param array $params, optional, can have keys 'reshares' (bool), 'subfiles' (bool)
      * @return NextcloudResponse
      */
-    public function getSharesFromFileOrFolder($path, array $params) {
+    public function getSharesFromFileOrFolder($path, array $params = []) {
 
         $params = $this->resolve($params, function(OptionsResolver $resolver) {
             $resolver->setDefaults([
-                'reshares',
-                'subfiles'
+                'reshares'	=> null,
+                'subfiles'	=> null
             ]);
         });
 
         $params = array_merge($params, ['path' => $path]);
 
-        return $this->connection->request(Connection::GET, self::SHARE_PART . '/' . $this->buildUriParams($params));
+        return $this->connection->request(Connection::GET, self::SHARE_PART . $this->buildUriParams($params));
     }
 
     /**

--- a/src/NextcloudApiWrapper/SharesClient.php
+++ b/src/NextcloudApiWrapper/SharesClient.php
@@ -62,7 +62,8 @@ class SharesClient extends AbstractClient
             ])->setDefaults([
                 'publicUpload'  => null,
                 'password'      => null,
-                'permissions'   => null
+                'permissions'   => null,
+                'expireDate'    => null
             ]);
         });
 

--- a/src/NextcloudApiWrapper/SharesClient.php
+++ b/src/NextcloudApiWrapper/SharesClient.php
@@ -34,7 +34,7 @@ class SharesClient extends AbstractClient
 
         $params = array_merge($params, ['path' => $path]);
 
-        return $this->connection->request(Connection::GET, self::SHARE_PART . $this->buildUriParams($params));
+        return $this->connection->pushDataRequest(Connection::GET, self::SHARE_PART . $this->buildUriParams($params));
     }
 
     /**
@@ -89,7 +89,7 @@ class SharesClient extends AbstractClient
      */
     public function updateShare($shareid, $key, $value) {
 
-        $this->inArray($key, ['permissions', 'password', 'publicUpload', 'expireDate']);
+        $this->inArray($key, ['permissions', 'password', 'publicUpload', 'expireDate', 'note']);
 
         return $this->connection->pushDataRequest(Connection::PUT, self::SHARE_PART . '/' . $shareid, [
             $key => $value


### PR DESCRIPTION
Added missing `expireDate` parameter on `createShare()` and fixed broken `getSharesFromFileOrFolder()` and `updateShare()`

Ref.: https://docs.nextcloud.com/server/latest/developer_manual/client_apis/OCS/ocs-share-api.html#create-a-new-share